### PR TITLE
Athena support

### DIFF
--- a/integration_tests/deprecated_tests/macros/e2e_tests/validate_freshness_anomalies.sql
+++ b/integration_tests/deprecated_tests/macros/e2e_tests/validate_freshness_anomalies.sql
@@ -4,7 +4,7 @@
     {% set freshness_validation_query %}
         select distinct table_name
         from {{ alerts_relation }}
-        where sub_type = 'event_freshness' and detected_at >= {{ max_bucket_end }}
+        where sub_type = 'event_freshness' and detected_at >= {{elementary.edr_cast_as_timestamp(max_bucket_end) }}
     {% endset %}
 
     {% set results = elementary.result_column_to_list(freshness_validation_query) %}

--- a/macros/edr/alerts/anomaly_detection_description.sql
+++ b/macros/edr/alerts/anomaly_detection_description.sql
@@ -9,21 +9,21 @@
 {% endmacro %}
 
 {% macro freshness_description() %}
-    'Last update was at ' || anomalous_value || ', ' || abs(round({{ elementary.edr_cast_as_numeric('metric_value/3600') }}, 2)) || ' hours ago. Usually the table is updated within ' || abs(round({{ elementary.edr_cast_as_numeric('training_avg/3600') }}, 2)) || ' hours.'
+    'Last update was at ' || anomalous_value || ', ' || {{ elementary.edr_cast_as_string('abs(round(' ~ elementary.edr_cast_as_numeric('metric_value/3600') ~ ', 2))') }} || ' hours ago. Usually the table is updated within ' || {{ elementary.edr_cast_as_string('abs(round(' ~ elementary.edr_cast_as_numeric('training_avg/3600') ~ ', 2))') }} || ' hours.'
 {% endmacro %}
 
 {% macro table_metric_description() %}
-    'The last ' || metric_name || ' value is ' || round({{ elementary.edr_cast_as_numeric('metric_value') }}, 3) ||
-    '. The average for this metric is ' || round({{ elementary.edr_cast_as_numeric('training_avg') }}, 3) || '.'
+    'The last ' || metric_name || ' value is ' || {{ elementary.edr_cast_as_string('round(' ~ elementary.edr_cast_as_numeric('metric_value') ~ ', 3)') }} ||
+    '. The average for this metric is ' || {{ elementary.edr_cast_as_string('round(' ~ elementary.edr_cast_as_numeric('training_avg') ~ ', 3)') }} || '.'
 {% endmacro %}
 
 {% macro column_metric_description() %}
-    'In column ' || column_name || ', the last ' || metric_name || ' value is ' || round({{ elementary.edr_cast_as_numeric('metric_value') }}, 3) ||
-    '. The average for this metric is ' || round({{ elementary.edr_cast_as_numeric('training_avg') }}, 3) || '.'
+    'In column ' || column_name || ', the last ' || metric_name || ' value is ' || {{ elementary.edr_cast_as_string('round(' ~ elementary.edr_cast_as_numeric('metric_value') ~ ', 3)') }} ||
+    '. The average for this metric is ' || {{ elementary.edr_cast_as_string('round(' ~ elementary.edr_cast_as_numeric('training_avg') ~ ', 3)') }} || '.'
 {% endmacro %}
 
 {% macro dimension_metric_description() %}
     'The last ' || metric_name || ' value for dimension ' || dimension || ' - ' ||
-    case when dimension_value is null then 'NULL' else dimension_value end || ' is ' || round({{ elementary.edr_cast_as_numeric('metric_value') }}, 3) ||
-    '. The average for this metric is ' || round({{ elementary.edr_cast_as_numeric('training_avg') }}, 3) || '.'
+    case when dimension_value is null then 'NULL' else dimension_value end || ' is ' || {{ elementary.edr_cast_as_string('round(' ~ elementary.edr_cast_as_numeric('metric_value') ~ ', 3)') }} ||
+    '. The average for this metric is ' || {{ elementary.edr_cast_as_string('round(' ~ elementary.edr_cast_as_numeric('training_avg') ~ ', 3)') }} || '.'
 {% endmacro %}

--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
@@ -164,8 +164,8 @@
                 end as anomaly_score,
                 {{ test_configuration.anomaly_sensitivity }} as anomaly_score_threshold,
                 source_value as anomalous_value,
-                bucket_start,
-                bucket_end,
+                {{ elementary.edr_cast_as_timestamp('bucket_start') }} as bucket_start,
+                {{ elementary.edr_cast_as_timestamp('bucket_end') }} as bucket_end,
                 bucket_seasonality,
                 metric_value,
                 {% set min_metric_value_expr %}
@@ -183,8 +183,8 @@
                 training_avg,
                 training_stddev,
                 training_set_size,
-                training_start,
-                training_end,
+                {{ elementary.edr_cast_as_timestamp('training_start') }} as training_start,
+                {{ elementary.edr_cast_as_timestamp('training_end') }} as training_end,
                 dimension,
                 dimension_value
             from time_window_aggregation

--- a/macros/edr/dbt_artifacts/dbt_columns/get_dbt_columns_materialization.sql
+++ b/macros/edr/dbt_artifacts/dbt_columns/get_dbt_columns_materialization.sql
@@ -14,3 +14,8 @@
 {% macro bigquery__get_dbt_columns_materialized() %}
   {% do return("incremental") %}
 {% endmacro %}
+
+
+{% macro athena__get_dbt_columns_materialized() %}
+  {% do return("table") %}
+{% endmacro %}

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -203,7 +203,7 @@
         'test_execution_id': test_execution_id,
         'test_unique_id': elementary.insensitive_get_dict_value(flattened_test, 'unique_id'),
         'model_unique_id': parent_model_unique_id,
-        'detected_at': elementary.edr_cast_as_timestamp("'" ~ elementary.insensitive_get_dict_value(flattened_test, 'generated_at') ~ "'"),
+        'detected_at': elementary.insensitive_get_dict_value(flattened_test, 'generated_at'),
         'database_name': elementary.insensitive_get_dict_value(flattened_test, 'database_name'),
         'schema_name': elementary.insensitive_get_dict_value(flattened_test, 'schema_name'),
         'table_name': parent_model_name,

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -203,7 +203,7 @@
         'test_execution_id': test_execution_id,
         'test_unique_id': elementary.insensitive_get_dict_value(flattened_test, 'unique_id'),
         'model_unique_id': parent_model_unique_id,
-        'detected_at': elementary.insensitive_get_dict_value(flattened_test, 'generated_at'),
+        'detected_at': elementary.edr_cast_as_timestamp("'" ~ elementary.insensitive_get_dict_value(flattened_test, 'generated_at') ~ "'"),
         'database_name': elementary.insensitive_get_dict_value(flattened_test, 'database_name'),
         'schema_name': elementary.insensitive_get_dict_value(flattened_test, 'schema_name'),
         'table_name': parent_model_name,

--- a/macros/edr/metadata_collection/get_columns_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_columns_from_information_schema.sql
@@ -76,3 +76,16 @@
 {% macro get_empty_columns_from_information_schema_table() %}
     {{ elementary.empty_table([('full_table_name', 'string'), ('database_name', 'string'), ('schema_name', 'string'), ('table_name', 'string'), ('column_name', 'string'), ('data_type', 'string')]) }}
 {% endmacro %}
+
+{% macro athena__get_columns_from_information_schema(database_name, schema_name) %}
+    select
+        upper(table_catalog || '.' || table_schema || '.' || table_name) as full_table_name,
+        upper(table_catalog) as database_name,
+        upper(table_schema) as schema_name,
+        upper(table_name) as table_name,
+        upper(column_name) as column_name,
+        data_type
+    from information_schema.columns
+    where upper(table_schema) = upper('{{ schema_name }}')
+
+{% endmacro %}

--- a/macros/edr/metadata_collection/get_tables_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_tables_from_information_schema.sql
@@ -145,3 +145,22 @@
         ('table_name', 'string'),
     ]) }}
 {% endmacro %}
+
+{% macro athena__get_tables_from_information_schema(schema_tuple) %}
+    {%- set database_name, schema_name = schema_tuple %}
+
+    select
+        {{ elementary.full_table_name() }} as full_table_name,
+        upper(database_name || '.' || schema_name) as full_schema_name,
+        database_name,
+        schema_name,
+        table_name
+    from (
+        select
+            upper(table_catalog) as database_name,
+            upper(table_schema) as schema_name,
+            upper(table_name) as table_name
+        from information_schema.tables
+        where upper(table_schema) = upper('{{ schema_name }}') and upper(table_catalog) = upper('{{ database_name }}')
+    )
+{% endmacro %}

--- a/macros/edr/system/system_utils/buckets_cte.sql
+++ b/macros/edr/system/system_utils/buckets_cte.sql
@@ -95,3 +95,14 @@
     {%- endset %}
     {{ return(complete_buckets_cte) }}
 {% endmacro %}
+
+{% macro athena__complete_buckets_cte(time_bucket, bucket_end_expr, min_bucket_start_expr, max_bucket_end_expr) %}
+    {%- set complete_buckets_cte %}
+        select
+          edr_bucket_start,
+          {{ bucket_end_expr }} as edr_bucket_end
+        from unnest(sequence({{ min_bucket_start_expr }}, {{ max_bucket_end_expr }}, interval {{ time_bucket.count }} {{ time_bucket.period }})) as t(edr_bucket_start)
+        where {{ bucket_end_expr }} <= {{ max_bucket_end_expr }}
+    {%- endset %}
+    {{ return(complete_buckets_cte) }}
+{% endmacro %}

--- a/macros/edr/system/system_utils/buckets_cte.sql
+++ b/macros/edr/system/system_utils/buckets_cte.sql
@@ -101,7 +101,7 @@
         select
           edr_bucket_start,
           {{ bucket_end_expr }} as edr_bucket_end
-        from unnest(sequence({{ min_bucket_start_expr }}, {{ max_bucket_end_expr }}, interval {{ time_bucket.count }} {{ time_bucket.period }})) as t(edr_bucket_start)
+        from unnest(sequence({{ min_bucket_start_expr }}, {{ max_bucket_end_expr }}, interval '{{ time_bucket.count }}' {{ time_bucket.period }})) as t(edr_bucket_start)
         where {{ bucket_end_expr }} <= {{ max_bucket_end_expr }}
     {%- endset %}
     {{ return(complete_buckets_cte) }}

--- a/macros/edr/system/system_utils/buckets_cte.sql
+++ b/macros/edr/system/system_utils/buckets_cte.sql
@@ -101,7 +101,15 @@
         select
           edr_bucket_start,
           {{ bucket_end_expr }} as edr_bucket_end
-        from unnest(sequence({{ min_bucket_start_expr }}, {{ max_bucket_end_expr }}, interval '{{ time_bucket.count }}' {{ time_bucket.period }})) as t(edr_bucket_start)
+        from unnest(sequence(
+          {{ min_bucket_start_expr }},
+          {{ max_bucket_end_expr }},
+          {%- if time_bucket.period | lower == 'week' %}
+            interval '{{ time_bucket.count * 7 }}' day
+          {%- else %}
+            interval '{{ time_bucket.count }}' {{ time_bucket.period }}
+          {%- endif %}
+        )) as t(edr_bucket_start)
         where {{ bucket_end_expr }} <= {{ max_bucket_end_expr }}
     {%- endset %}
     {{ return(complete_buckets_cte) }}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -67,3 +67,9 @@
     {% do default_config.update({'query_max_size': 250000}) %}
     {{- return(default_config) -}}
 {%- endmacro -%}
+
+{%- macro athena__get_default_config() -%}
+    {% set default_config = elementary.default__get_default_config() %}
+    {% do default_config.update({'query_max_size': 250000}) %}
+    {{- return(default_config) -}}
+{%- endmacro -%}

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -30,6 +30,14 @@
     {% do return(elementary.get_transactionless_clean_elementary_test_tables_queries(test_table_relations)) %}
 {% endmacro %}
 
+{% macro athena__get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% set queries = [] %}
+    {% for test_relation in test_table_relations %}
+        {% do queries.append("DROP TABLE IF EXISTS {}".format(test_relation.render_pure())) %}
+    {% endfor %}
+    {% do return(queries) %}
+{% endmacro %}
+
 {% macro get_transaction_clean_elementary_test_tables_queries(test_table_relations) %}
     {% set query %}
         BEGIN TRANSACTION;

--- a/macros/utils/cross_db_utils/current_timestamp.sql
+++ b/macros/utils/cross_db_utils/current_timestamp.sql
@@ -46,3 +46,13 @@
 {% macro spark__edr_current_timestamp_in_utc() %}
     cast(unix_timestamp() as timestamp)
 {% endmacro %}
+
+{% macro athena__edr_current_timestamp() -%}
+    CURRENT_TIMESTAMP
+{%- endmacro -%}
+
+{% macro athena__edr_current_timestamp_in_utc() %}
+    (
+        CURRENT_TIMESTAMP AT TIME ZONE 'utc'
+    )
+{% endmacro %}

--- a/macros/utils/cross_db_utils/current_timestamp.sql
+++ b/macros/utils/cross_db_utils/current_timestamp.sql
@@ -51,8 +51,6 @@
     CURRENT_TIMESTAMP
 {%- endmacro -%}
 
-{% macro athena__edr_current_timestamp_in_utc() %}
-    (
-        CURRENT_TIMESTAMP AT TIME ZONE 'utc'
-    )
-{% endmacro %}
+{% macro athena__edr_current_timestamp_in_utc() -%}
+    cast(CURRENT_TIMESTAMP AT TIME ZONE 'utc' AS TIMESTAMP)
+{%- endmacro -%}

--- a/macros/utils/cross_db_utils/datediff.sql
+++ b/macros/utils/cross_db_utils/datediff.sql
@@ -25,3 +25,11 @@
         {{ exceptions.raise_compiler_error("Unsupported date_part in edr_datediff: ".format(date_part)) }}
     {%- endif %}
 {% endmacro %}
+
+{% macro athena__edr_datediff(first_date, second_date, date_part) %}
+    {% set macro = dbt.datediff or dbt_utils.datediff %}
+    {% if not macro %}
+        {{ exceptions.raise_compiler_error("Did not find a `datediff` macro.") }}
+    {% endif %}
+    {{ return(macro(elementary.edr_cast_as_date(first_date), elementary.edr_cast_as_date(second_date), date_part)) }}
+{% endmacro %}

--- a/macros/utils/cross_db_utils/day_of_week.sql
+++ b/macros/utils/cross_db_utils/day_of_week.sql
@@ -32,3 +32,7 @@
     0 , 'Sunday'
     )
 {% endmacro %}
+
+{% macro athena__edr_day_of_week_expression(date_expr) %}
+    DATE_FORMAT({{ date_expr }}, '%W')
+{% endmacro %}

--- a/macros/utils/cross_db_utils/generate_elementary_profile_args.sql
+++ b/macros/utils/cross_db_utils/generate_elementary_profile_args.sql
@@ -106,10 +106,10 @@
   {% set parameters = [
     _parameter("type", target.type),
     _parameter("s3_staging_dir", target.s3_staging_dir),
-    _parameter("region_name", target.region_name)
-    _parameter("database", target.database)
-    _parameter("aws_profile_name", target.aws_profile_name)
-    _parameter("work_group", target.work_group)
+    _parameter("region_name", target.region_name),
+    _parameter("database", target.database),
+    _parameter("aws_profile_name", target.aws_profile_name),
+    _parameter("work_group", target.work_group),
     _parameter("aws_access_key_id", "<AWS_ACCESS_KEY_ID>"),
     _parameter("aws_secret_access_key", "<AWS_SECRET_ACCESS_KEY>"),
   ] %}

--- a/macros/utils/cross_db_utils/generate_elementary_profile_args.sql
+++ b/macros/utils/cross_db_utils/generate_elementary_profile_args.sql
@@ -102,6 +102,30 @@
   {% do return(parameters) %}
 {% endmacro %}
 
+{% macro athena__generate_elementary_cli_profile(method, elementary_database, elementary_schema) %}
+  {% set parameters = [
+    _parameter("type", target.type),
+    _parameter("s3_staging_dir", target.s3_staging_dir),
+    _parameter("region_name", target.region_name)
+    _parameter("database", target.database)
+    _parameter("aws_profile_name", target.aws_profile_name)
+    _parameter("work_group", target.work_group)
+    _parameter("aws_access_key_id", "<AWS_ACCESS_KEY_ID>"),
+    _parameter("aws_secret_access_key", "<AWS_SECRET_ACCESS_KEY>"),
+  ] %}
+
+  {% if elementary_database %}
+    {% do parameters.append(_parameter("catalog", elementary_database)) %}
+  {% endif %}
+
+  {% do parameters.extend([
+    _parameter("schema", elementary_schema),
+    _parameter("token", "<TOKEN>"),
+    _parameter("threads", target.threads),
+  ]) %}
+  {% do return(parameters) %}
+{% endmacro %}
+
 {% macro default__generate_elementary_profile_args(method, elementary_database, elementary_schema) %}
 Adapter "{{ target.type }}" is not supported on Elementary.
 {% endmacro %}

--- a/macros/utils/cross_db_utils/hour_of_day.sql
+++ b/macros/utils/cross_db_utils/hour_of_day.sql
@@ -2,7 +2,7 @@
     {{ return(adapter.dispatch('edr_hour_of_day_expression','elementary')(elementary.edr_cast_as_timestamp(date_expr))) }}
 {% endmacro %}
 
-{# Databricks, Spark: #}
+{# Databricks, Spark, Athena: #}
 {% macro default__edr_hour_of_day_expression(date_expr) %}
     HOUR({{ date_expr }})
 {% endmacro %}

--- a/macros/utils/cross_db_utils/hour_of_week.sql
+++ b/macros/utils/cross_db_utils/hour_of_week.sql
@@ -30,3 +30,7 @@
     0 , 'Sunday'
     ) as {{ elementary.edr_type_string() }}),  cast(HOUR({{ date_expr }}) as {{ elementary.edr_type_string() }}))
 {% endmacro %}
+
+{% macro athena__edr_hour_of_week_expression(date_expr) %}
+    DATE_FORMAT({{ date_expr }}, '%W%H')
+{% endmacro %}

--- a/macros/utils/cross_db_utils/incremental_strategy.sql
+++ b/macros/utils/cross_db_utils/incremental_strategy.sql
@@ -1,0 +1,11 @@
+{% macro get_default_incremental_strategy() %}
+  {% do return(adapter.dispatch("get_default_incremental_strategy", "elementary")()) %}
+{% endmacro %}
+
+{%- macro athena__get_default_incremental_strategy() %}
+  {% do return("merge") %}
+{% endmacro %}
+
+{% macro default__get_default_incremental_strategy() %}
+  {% do return(none) %}
+{% endmacro %}

--- a/macros/utils/cross_db_utils/target_database.sql
+++ b/macros/utils/cross_db_utils/target_database.sql
@@ -18,3 +18,7 @@
 {% macro bigquery__target_database() %}
     {% do return(target.project) %}
 {% endmacro %}
+
+{% macro athena__target_database() %}
+    {% do return(target.database) %}
+{% endmacro %}

--- a/macros/utils/cross_db_utils/timeadd.sql
+++ b/macros/utils/cross_db_utils/timeadd.sql
@@ -27,5 +27,5 @@
 {% endmacro %}
 
 {% macro athena__edr_timeadd(date_part, number, timestamp_expression) %}
-    date_add('{{ datepart }}', {{ elementary.edr_cast_as_int(number) }}, {{ elementary.edr_cast_as_timestamp(timestamp_expression) }})
+    date_add('{{ date_part }}', {{ elementary.edr_cast_as_int(number) }}, {{ elementary.edr_cast_as_timestamp(timestamp_expression) }})
 {% endmacro %}

--- a/macros/utils/cross_db_utils/timeadd.sql
+++ b/macros/utils/cross_db_utils/timeadd.sql
@@ -25,3 +25,7 @@
 {% macro redshift__edr_timeadd(date_part, number, timestamp_expression) %}
     dateadd({{ date_part }}, {{ elementary.edr_cast_as_int(number) }}, {{ elementary.edr_cast_as_timestamp(timestamp_expression) }})
 {% endmacro %}
+
+{% macro athena__edr_timeadd(date_part, number, timestamp_expression) %}
+    date_add('{{ datepart }}', {{ elementary.edr_cast_as_int(number) }}, {{ elementary.edr_cast_as_timestamp(timestamp_expression) }})
+{% endmacro %}

--- a/macros/utils/data_types/data_type.sql
+++ b/macros/utils/data_types/data_type.sql
@@ -101,6 +101,10 @@
 
 
 {% macro edr_type_timestamp() %}
+    {{ return(adapter.dispatch('edr_type_timestamp', 'elementary')()) }}
+{% endmacro %}
+
+{% macro default__edr_type_timestamp() %}
     {% set macro = dbt.type_timestamp or dbt_utils.type_timestamp %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `type_timestamp` macro.") }}
@@ -128,4 +132,8 @@
 
 {% macro bigquery__edr_type_date() %}
     date
+{% endmacro %}
+
+{% macro athena__edr_type_timestamp() %}
+    timestamp(6)
 {% endmacro %}

--- a/macros/utils/data_types/data_type.sql
+++ b/macros/utils/data_types/data_type.sql
@@ -140,5 +140,11 @@
 {% endmacro %}
 
 {% macro athena__edr_type_timestamp() %}
+  {%- set config = model.get('config', {}) -%}
+  {%- set table_type = config.get('table_type', 'glue') -%}
+  {%- if table_type == 'iceberg' -%}
     timestamp(6)
+  {%- else -%}
+    timestamp
+  {%- endif -%}
 {% endmacro %}

--- a/macros/utils/data_types/data_type.sql
+++ b/macros/utils/data_types/data_type.sql
@@ -51,6 +51,11 @@
     {% do return("string") %}
 {% endmacro %}
 
+{% macro athena__edr_type_string() %}
+    {% do return("varchar") %}
+{% endmacro %}
+
+
 
 
 {%- macro edr_type_long_string() -%}

--- a/macros/utils/table_operations/create_or_replace.sql
+++ b/macros/utils/table_operations/create_or_replace.sql
@@ -25,3 +25,12 @@
     {% do elementary.run_query(dbt.create_table_as(temporary, relation, sql_query)) %}
     {% do adapter.commit() %}
 {% endmacro %}
+
+{% macro athena__create_or_replace(temporary, relation, sql_query) %}
+    {% set drop_query %}
+        drop table if exists {{ relation.schema }}.{{ relation.identifier }}
+    {% endset %}
+    {% do elementary.run_query(drop_query) %}
+    {% do run_query(dbt.create_table_as(temporary, relation, sql_query)) %}
+    {% do adapter.commit() %}
+{% endmacro %}

--- a/macros/utils/table_operations/create_or_replace.sql
+++ b/macros/utils/table_operations/create_or_replace.sql
@@ -27,10 +27,7 @@
 {% endmacro %}
 
 {% macro athena__create_or_replace(temporary, relation, sql_query) %}
-    {% set drop_query %}
-        drop table if exists {{ relation.schema }}.{{ relation.identifier }}
-    {% endset %}
-    {% do elementary.run_query(drop_query) %}
-    {% do run_query(dbt.create_table_as(temporary, relation, sql_query)) %}
+    {% do dbt.drop_relation_if_exists(relation) %}
+    {% do elementary.run_query(dbt.create_table_as(temporary, relation, sql_query)) %}
     {% do adapter.commit() %}
 {% endmacro %}

--- a/macros/utils/table_operations/delete_and_insert.sql
+++ b/macros/utils/table_operations/delete_and_insert.sql
@@ -86,3 +86,26 @@
 
     {% do return(queries) %}
 {% endmacro %}
+
+{% macro athena__get_delete_and_insert_queries(relation, insert_relation, delete_relation, delete_column_key) %}
+    {% set queries = [] %}
+
+    {% if delete_relation %}
+        {% set delete_query %}
+            delete from {{ relation }}
+            where
+            {{ delete_column_key }} is null
+            or {{ delete_column_key }} in (select {{ delete_column_key }} from {{ delete_relation }});
+        {% endset %}
+        {% do queries.append(delete_query) %}
+    {% endif %}
+
+    {% if insert_relation %}
+        {% set insert_query %}
+            insert into {{ relation }} select * from {{ insert_relation }};
+        {% endset %}
+        {% do queries.append(insert_query) %}
+    {% endif %}
+
+    {% do return(queries) %}
+{% endmacro %}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -121,7 +121,11 @@
         {%- if value is number -%}
             {{- value -}}
         {%- elif value is string -%}
-            '{{- elementary.escape_special_chars(value) -}}'
+            {%- if value.startswith('cast(')  -%}
+              {{- value -}}
+            {%- else -%}
+              '{{- elementary.escape_special_chars(value) -}}'
+            {%- endif -%}
         {%- elif value is mapping or value is sequence -%}
             '{{- elementary.escape_special_chars(tojson(value)) -}}'
         {%- else -%}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -116,6 +116,10 @@
     {{- return(string_value | replace("'", "''")) -}}
 {%- endmacro -%}
 
+{%- macro athena__escape_special_chars(string_value) -%}
+    {{- return(string_value | replace("'", "''")) -}}
+{%- endmacro -%}
+
 {%- macro render_value(value) -%}
     {%- if value is defined and value is not none -%}
         {%- if value is number -%}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -127,6 +127,8 @@
         {%- elif value is string -%}
             {%- if value.startswith('cast(')  -%}
               {{- value -}}
+            {%- elif value.startswith('coalesce(') -%}
+              {{- value -}}
             {%- else -%}
               '{{- elementary.escape_special_chars(value) -}}'
             {%- endif -%}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -57,7 +57,8 @@
           {% do rendered_column_values.append(column_value) %}
         {% else %}
           {% set column_value = elementary.insensitive_get_dict_value(row, column.name) %}
-          {% do rendered_column_values.append(elementary.render_value(column_value)) %}
+          {% set normalized_data_type = elementary.normalize_data_type(column.dtype) %}
+          {% do rendered_column_values.append(elementary.render_value(column_value, normalized_data_type)) %}
         {% endif %}
       {% endfor %}
       {% set row_sql = "({})".format(rendered_column_values | join(",")) %}
@@ -120,18 +121,14 @@
     {{- return(string_value | replace("'", "''")) -}}
 {%- endmacro -%}
 
-{%- macro render_value(value) -%}
+{%- macro render_value(value, data_type) -%}
     {%- if value is defined and value is not none -%}
         {%- if value is number -%}
             {{- value -}}
+        {%- elif value is string and data_type == 'timestamp' -%}
+            {{- elementary.edr_cast_as_timestamp(elementary.edr_quote(value)) -}}
         {%- elif value is string -%}
-            {%- if value.startswith('cast(')  -%}
-              {{- value -}}
-            {%- elif value.startswith('coalesce(') -%}
-              {{- value -}}
-            {%- else -%}
-              '{{- elementary.escape_special_chars(value) -}}'
-            {%- endif -%}
+            '{{- elementary.escape_special_chars(value) -}}'
         {%- elif value is mapping or value is sequence -%}
             '{{- elementary.escape_special_chars(tojson(value)) -}}'
         {%- else -%}

--- a/macros/utils/table_operations/merge_sql.sql
+++ b/macros/utils/table_operations/merge_sql.sql
@@ -19,3 +19,29 @@
     {% do return(macro(target_relation, tmp_relation, unique_key, dest_columns)) %}
     {{ return(merge_sql) }}
 {% endmacro %}
+
+{% macro athena__merge_sql(target_relation, tmp_relation, unique_key, dest_columns, incremental_predicates) %}
+
+    {% set query %}
+      merge into {{ target_relation }} as target using {{ tmp_relation }} as src
+      ON (target.{{unique_key}} = src.{{ unique_key}})
+      when matched
+      then update set
+      {%- for col in dest_columns %}
+          {{ col.column }} = src.{{ col.column }} {{ ", " if not loop.last }}
+      {%- endfor %}
+      when not matched
+        then insert (
+        {%- for col in dest_columns %}
+            {{ col.column }} {{ ", " if not loop.last }}
+        {%- endfor %}
+
+        )
+        values (
+        {%- for col in dest_columns %}
+            src.{{ col.column }} {{ ", " if not loop.last }}
+        {%- endfor %}
+        )
+    {% endset %}
+    {% do return(query) %}
+{% endmacro %}

--- a/macros/utils/table_operations/replace_table_data.sql
+++ b/macros/utils/table_operations/replace_table_data.sql
@@ -38,3 +38,9 @@
 
     {% do adapter.drop_relation(intermediate_relation) %}
 {% endmacro %}
+
+{% macro athena__replace_table_data(relation, rows) %}
+    {% set intermediate_relation = elementary.create_intermediate_relation(relation, rows, temporary=True) %}
+    {% do elementary.create_or_replace(False, relation, 'select * from {}'.format(intermediate_relation)) %}
+    {% do adapter.drop_relation(intermediate_relation) %}
+{% endmacro %}

--- a/macros/utils/table_operations/replace_table_data.sql
+++ b/macros/utils/table_operations/replace_table_data.sql
@@ -40,7 +40,8 @@
 {% endmacro %}
 
 {% macro athena__replace_table_data(relation, rows) %}
-    {% set intermediate_relation = elementary.create_intermediate_relation(relation, rows, temporary=True) %}
-    {% do elementary.create_or_replace(False, relation, 'select * from {}'.format(intermediate_relation)) %}
-    {% do adapter.drop_relation(intermediate_relation) %}
+     {% call statement('truncate_relation') -%}
+        delete from {{ relation }}
+      {%- endcall %}
+    {% do elementary.insert_rows(relation, rows, should_commit=false, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
 {% endmacro %}

--- a/models/edr/alerts/alerts_anomaly_detection.sql
+++ b/models/edr/alerts/alerts_anomaly_detection.sql
@@ -15,7 +15,7 @@ alerts_anomaly_detection as (
            test_execution_id,
            test_unique_id,
            model_unique_id,
-           detected_at,
+           {{ elementary.edr_cast_as_timestamp("detected_at") }} as detected_at,
            database_name,
            schema_name,
            table_name,

--- a/models/edr/alerts/alerts_dbt_models.sql
+++ b/models/edr/alerts/alerts_dbt_models.sql
@@ -63,7 +63,7 @@ with error_models as (
 
 select model_execution_id as alert_id,
        unique_id,
-       generated_at as detected_at,
+       {{ elementary.edr_cast_as_timestamp("generated_at") }} as detected_at,
        database_name,
        materialization,
        path,

--- a/models/edr/alerts/alerts_dbt_source_freshness.sql
+++ b/models/edr/alerts/alerts_dbt_source_freshness.sql
@@ -17,7 +17,7 @@ select
   results.source_freshness_execution_id as alert_id,
   results.max_loaded_at,
   results.snapshotted_at,
-  results.generated_at as detected_at,
+  {{ elementary.edr_cast_as_timestamp("results.generated_at") }} as detected_at,
   results.max_loaded_at_time_ago_in_s,
   results.status,
   results.error,

--- a/models/edr/alerts/alerts_dbt_tests.sql
+++ b/models/edr/alerts/alerts_dbt_tests.sql
@@ -15,7 +15,7 @@ alerts_dbt_tests as (
            test_execution_id,
            test_unique_id,
            model_unique_id,
-           detected_at,
+           {{ elementary.edr_cast_as_timestamp("detected_at") }} detected_at,
            database_name,
            schema_name,
            table_name,

--- a/models/edr/alerts/alerts_schema_changes.sql
+++ b/models/edr/alerts/alerts_schema_changes.sql
@@ -16,7 +16,7 @@ alerts_schema_changes as (
            test_execution_id,
            test_unique_id,
            model_unique_id,
-           detected_at,
+           {{ elementary.edr_cast_as_timestamp("detected_at") }} detected_at,
            database_name,
            schema_name,
            table_name,

--- a/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
+++ b/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
@@ -8,6 +8,8 @@
       "timestamp_column": "created_at",
       "prev_timestamp_column": "updated_at",
       }
+    table_type="iceberg",
+    incremental_strategy="merge"
   )
 }}
 

--- a/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
+++ b/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
@@ -7,7 +7,7 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "updated_at",
-      }
+      },
     table_type="iceberg",
     incremental_strategy="merge"
   )

--- a/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
+++ b/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
@@ -9,7 +9,7 @@
       "prev_timestamp_column": "updated_at",
       },
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy(),
   )
 }}
 

--- a/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
+++ b/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
@@ -8,6 +8,8 @@
       "timestamp_column": "created_at",
       "prev_timestamp_column": "detected_at",
       }
+    table_type="iceberg",
+    incremental_strategy="merge"
   )
 }}
 

--- a/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
+++ b/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
@@ -9,7 +9,7 @@
       "prev_timestamp_column": "detected_at",
       },
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
+++ b/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
@@ -7,7 +7,7 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "detected_at",
-      }
+      },
     table_type="iceberg",
     incremental_strategy="merge"
   )

--- a/models/edr/dbt_artifacts/dbt_exposures.sql
+++ b/models/edr/dbt_artifacts/dbt_exposures.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_exposures.sql
+++ b/models/edr/dbt_artifacts/dbt_exposures.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_exposures() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_invocations.sql
+++ b/models/edr/dbt_artifacts/dbt_invocations.sql
@@ -8,7 +8,9 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "generated_at",
-      }
+      },
+    table_type="iceberg",
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_metrics.sql
+++ b/models/edr/dbt_artifacts/dbt_metrics.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_metrics() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_metrics.sql
+++ b/models/edr/dbt_artifacts/dbt_metrics.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_models.sql
+++ b/models/edr/dbt_artifacts/dbt_models.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_models.sql
+++ b/models/edr/dbt_artifacts/dbt_models.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_models() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_run_results.sql
+++ b/models/edr/dbt_artifacts/dbt_run_results.sql
@@ -8,7 +8,9 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "generated_at",
-      }
+      },
+    table_type="iceberg",
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_seeds.sql
+++ b/models/edr/dbt_artifacts/dbt_seeds.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_seeds.sql
+++ b/models/edr/dbt_artifacts/dbt_seeds.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_seeds() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_snapshots.sql
+++ b/models/edr/dbt_artifacts/dbt_snapshots.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_snapshots.sql
+++ b/models/edr/dbt_artifacts/dbt_snapshots.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_snapshots() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_sources.sql
+++ b/models/edr/dbt_artifacts/dbt_sources.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_sources() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_sources.sql
+++ b/models/edr/dbt_artifacts/dbt_sources.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_tests.sql
+++ b/models/edr/dbt_artifacts/dbt_tests.sql
@@ -5,7 +5,9 @@
     post_hook='{{ elementary.upload_dbt_tests() }}',
     unique_key='unique_id',
     on_schema_change='sync_all_columns',
-    full_refresh=elementary.get_config_var('elementary_full_refresh')
+    full_refresh=elementary.get_config_var('elementary_full_refresh'),
+    table_type="iceberg",
+    incremental_strategy="merge"
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_tests.sql
+++ b/models/edr/dbt_artifacts/dbt_tests.sql
@@ -7,7 +7,7 @@
     on_schema_change='sync_all_columns',
     full_refresh=elementary.get_config_var('elementary_full_refresh'),
     table_type="iceberg",
-    incremental_strategy="merge"
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/metadata_store/filtered_information_schema_columns.sql
+++ b/models/edr/metadata_store/filtered_information_schema_columns.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    materialized = 'view',
+    materialized = 'table' if target.type == 'athena' else 'view',
   )
 }}
 

--- a/models/edr/run_results/dbt_source_freshness_results.sql
+++ b/models/edr/run_results/dbt_source_freshness_results.sql
@@ -7,7 +7,9 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "generated_at",
-      }
+      },
+    table_type="iceberg",
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/run_results/elementary_test_results.sql
+++ b/models/edr/run_results/elementary_test_results.sql
@@ -7,7 +7,9 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "detected_at",
-      }
+      },
+    table_type="iceberg",
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 

--- a/models/edr/run_results/test_result_rows.sql
+++ b/models/edr/run_results/test_result_rows.sql
@@ -8,7 +8,9 @@
     meta={
       "timestamp_column": "created_at",
       "prev_timestamp_column": "detected_at",
-      }
+      },
+    table_type="iceberg",
+    incremental_strategy=elementary.get_default_incremental_strategy()
   )
 }}
 


### PR DESCRIPTION
Athena support for elementary. Limited to Athena 3 and iceberg tables for incremental elementary tables. Testing with dbt-core 1.6.1, dbt-athena-community 1.6.0.

Clean rebase of https://github.com/artem-garmash/dbt-data-reliability/pull/1

- [x] Fix timestamp literals insert
- [x]  Fix explicit `DROP` in `athena__create_or_replace`
- [x] Integration tests
  - [x] test_anomalyless_all_columns_anomalies
  - [x] test_artifacts
  - [x] test_column_anomalies
  - [x] test_dimension_anomalies
  - [x] test_event_freshness_anomalies
  - [x] test_failed_row_count
  - [x] test_freshness_anomalies
  - [x] test_jsonschema
  - [ ] <s>test_metrics</s> (metrics ignored by missing `require_partition_filter`)
  - [ ] <s>test_python</s>
  - [ ] <s>test_schema_changes</s> (filtered_information_schema_columns is not updated with table materialization)
  - [x] test_volume_anomalies
- [x] DB specific model settings (e.g. `table_type="iceberg") or using dbt schema config?
